### PR TITLE
Support Embroider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
           - ember-canary
           - ember-default-with-jquery
           - ember-classic
+          - embroider-safe
+          - embroider-optimized
         include:
           - scenario: ember-release
             annotations: acceptance

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -79,8 +80,10 @@ module.exports = async function() {
         command: 'npm run nodetest',
         npm: {
           devDependencies: {}
-        }
-      }
+        },
+      },
+      embroiderSafe(),
+      embroiderOptimized()
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,5 +14,6 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,5 +15,14 @@ module.exports = function(defaults) {
   */
 
   const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app);
+  return maybeEmbroider(app, {
+    packagerOptions: {
+      webpackConfig: {
+        devtool: false,
+        node: {
+          fs: 'empty', // this is needed for yadda :( https://github.com/acuminous/yadda/blob/master/lib/shims/index.js#L12
+        },
+      },
+    },
+  });
 };

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -28,19 +28,21 @@ class FeatureParser extends Filter {
 
     let feature = new yadda.parsers.FeatureParser(this.yaddaOptions).parse(content);
     let pathParts = relativePath.split('/');
-    let basePath = pathParts.slice(0, 2).join('/');
+    // normalize path to always start from the `tests` folder, as this can be different in Embroider
+    pathParts.splice(0, pathParts.findIndex(p => p === 'tests'));
+
     let fileName = pathParts.slice(-1)[0].split('.')[0]; //remove extension
 
-    let testFolder = pathParts[2];
-    let nestedFolderParts = pathParts.slice(3, -1);
-    let stepsPath = [basePath, testFolder, 'steps', ...nestedFolderParts].join('/');
-
-    // import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
+    let testFolder = pathParts[1];
+    let nestedFolderParts = pathParts.slice(2, -1);
+    let relativePathToTests = Array(nestedFolderParts.length + 1).fill('..');
+    let stepsPath = [...relativePathToTests, testFolder, 'steps', ...nestedFolderParts].join('/');
+    let testPath = relativePathToTests.join('/');
 
     let module = `
       import yadda from 'yadda';
       import * as library from '${stepsPath}/${fileName}-steps';
-      import yaddaAnnotations from '${basePath}/helpers/yadda-annotations';
+      import * as yaddaAnnotations from '${testPath}/helpers/yadda-annotations';
       import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
 
       const feature = ${JSON.stringify(feature, null, 2)};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@embroider/test-setup": "^0.28.0",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -32,19 +32,18 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-persistent-filter": "^1.4.3",
-    "ember-auto-import": "^1.2.13",
+    "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "yadda": "*"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@embroider/test-setup": "^0.28.0",
+    "@embroider/test-setup": "^0.30.0",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.6.0",
     "ember-cli": "~3.22.0",
     "ember-cli-blueprint-test-helpers": "^0.18.3",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,14 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
+"@embroider/test-setup@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.30.0.tgz#a0fb48214b272bb6dd0d84ac1b668312ffc766e1"
+  integrity sha512-i1Nb5Z7NSw7OikfNf6OQE4ZL3RT1S1NFYrGe4r8qlX3u0oBLDMAC8RE7uO4WBn3sof2GoWmA9AL7RniuUGugdQ==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.1.tgz#f72069c330461a06684d119384435e12a5d76e3c"
@@ -4904,7 +4912,7 @@ ember-assign-polyfill@^2.6.0:
     ember-cli-babel "^7.20.5"
     ember-cli-version-checker "^2.0.0"
 
-ember-auto-import@^1.2.13:
+ember-auto-import@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.7.0.tgz#dd809fbe3d40647f2af443072405094d0e77ecf5"
   integrity sha512-onp7XZKwiit3BgkOPV/obi3fvLJmDNKTTjRsVtYz63yWeyT3ahiM8BIvJYzHGL4cxlGLvwpTJy2HYBDs6ZtvoQ==


### PR DESCRIPTION
There were two issues here how the `FeatureParser` generated imports, that *somehow* worked in a classic build, but broke in Embroider:
* the default export of `yadda-annotations.js` was imported, though that doesn't even exist, it only has named exports. Probably the way ember-cli transpiles ES modules to AMD made this work accidentally!? 
* the import path of the steps file was something like `tests/accpetance/steps/foo-steps.js`, which is neither an absolute path (there is no `tests` package) nor a relative. Changed to use relative paths (`./steps/foo-steps.js`)

Also adds additional test scenarios for Embroider, using their new test infrastructure.

This is based on top of #83, as it would have merge conflicts otherwise, so best review by commit. 